### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 php:
     - 7.1
     - 7.2
+    - 7.3
 
 cache:
     directories:

--- a/tests/Benchmark/ConfigLoaderBench.php
+++ b/tests/Benchmark/ConfigLoaderBench.php
@@ -38,7 +38,7 @@ class ConfigLoaderBench extends TestCase
      */
     private $config2yaml;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->config1 = $this->workspace->path('config1.json');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ class TestCase extends PhpunitTestCase
      */
     protected $workspace;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->workspace = Workspace::create(__DIR__  . '/Workspace');
         $this->workspace->reset();

--- a/tests/Unit/Adapter/Deserializer/JsonDeserializerTest.php
+++ b/tests/Unit/Adapter/Deserializer/JsonDeserializerTest.php
@@ -11,6 +11,14 @@ class JsonDeserializerTest extends TestCase
     public function testThrowsExceptionIfInvalidJson()
     {
         $this->expectException(CouldNotDeserialize::class);
+        $this->expectExceptionMessage('Could not decode JSON: "Syntax error"');
         (new JsonDeserializer())->deserialize('FOo BAR');
+    }
+
+    public function testDeserialize()
+    {
+        $decoded = (new JsonDeserializer())->deserialize('{"key": "value"}');
+
+        $this->assertSame(['key' => 'value'], $decoded);
     }
 }

--- a/tests/Unit/Adapter/Deserializer/YamlDeserializerTest.php
+++ b/tests/Unit/Adapter/Deserializer/YamlDeserializerTest.php
@@ -11,10 +11,15 @@ class YamlDeserializerTest extends TestCase
     public function testExceptionOnInvalid()
     {
         $this->expectException(CouldNotDeserialize::class);
+        $this->expectExceptionMessage(
+            <<<'EOT'
+Could not deserialize YAML, error from parser "Unable to parse at line 1 (near "asd")."
+EOT
+        );
         (new YamlDeserializer())->deserialize(
             <<<'EOT'
-asd 
- \t 
+asd
+ \t
 a
  1235
      123

--- a/tests/Unit/Adapter/PathCandidate/AbsolutePathCandidateTest.php
+++ b/tests/Unit/Adapter/PathCandidate/AbsolutePathCandidateTest.php
@@ -11,6 +11,7 @@ class AbsolutePathCandidateTest extends TestCase
     public function testExceptionifNotAbsolute()
     {
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Path is not absolute "hello"');
         new AbsolutePathCandidate('hello', 'foo');
     }
 }

--- a/tests/Unit/Core/ConfigLoaderTest.php
+++ b/tests/Unit/Core/ConfigLoaderTest.php
@@ -17,7 +17,7 @@ class ConfigLoaderTest extends TestCase
     private $deserializer;
 
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->deserializer = $this->prophesize(Deserializer::class);
@@ -120,7 +120,7 @@ class ConfigLoaderTest extends TestCase
         $configFile2 = $this->workspace->path('barfoo.test');
         file_put_contents($configFile1, 'test1');
         file_put_contents($configFile2, 'test2');
-        
+
         $loader = new ConfigLoader(
             new Deserializers([
                 'test' => $this->deserializer->reveal()

--- a/tests/Unit/Core/DeserializersTest.php
+++ b/tests/Unit/Core/DeserializersTest.php
@@ -14,7 +14,7 @@ class DeserializersTest extends TestCase
      */
     private $deserializer;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->deserializer = $this->prophesize(Deserializer::class);
     }


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test on Travis CI build.
- Add the `testDeserialize` to test the `JsonDeserializer::deserialize` method.
- Using the `expectExceptionMessage` to check whether the expected exception message is same as result.
- According to the [Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `PPHUnit\Framework\TestCase::setUp` should be `protected`, not `public`.